### PR TITLE
feat/#19: 토큰 만료 시간 설정

### DIFF
--- a/react-client/src/App.js
+++ b/react-client/src/App.js
@@ -1,26 +1,52 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import SignUp from './SignUp'
 import Login from './Login'
 import Dashboard from './Dashboard'
-import Message from './pages/Message'   // ✅ 추가
+import Message from './pages/Message'
+import { supabase } from './supabaseClient'
+import { endSession } from './utils/sessionManager'
 
 
 function App() {
     const [page, setPage] = useState('signup')
+    const [isLoggedIn, setIsLoggedIn] = useState(false)
+
+    // 로그인 상태 확인
+    useEffect(() => {
+        const checkSession = async () => {
+            const { data: { session } } = await supabase.auth.getSession()
+            setIsLoggedIn(!!session)
+        }
+        checkSession()
+    }, [page])
+
+    // 로그아웃 처리
+    const handleLogout = async () => {
+        await supabase.auth.signOut()
+        endSession() // 세션 만료 시간도 초기화
+        setIsLoggedIn(false)
+        setPage('login')
+    }
 
     return (
         <div style={{ textAlign: 'center', marginTop: 50 }}>
             <div>
                 <button onClick={() => setPage('signup')}>회원가입</button>
-                <button onClick={() => setPage('login')}>로그인</button>
+                {isLoggedIn ? (
+                    <button onClick={handleLogout} style={{ backgroundColor: '#ff4444', color: 'white' }}>
+                        로그아웃
+                    </button>
+                ) : (
+                    <button onClick={() => setPage('login')}>로그인</button>
+                )}
                 <button onClick={() => setPage('dashboard')}>대시보드</button>
                 <button onClick={() => setPage('message')}>메시지</button>
             </div>
 
-            {page === 'signup' && <SignUp />}
-            {page === 'login' && <Login />}
-            {page === 'dashboard' && <Dashboard />}
-            {page === 'message' && <Message />}
+            {page === 'signup' && <SignUp onLogin={() => setIsLoggedIn(true)} />}
+            {page === 'login' && <Login onLogin={() => setIsLoggedIn(true)} />}
+            {page === 'dashboard' && <Dashboard setPage={setPage} />}
+            {page === 'message' && <Message setPage={setPage} />}
         </div>
     )
 }

--- a/react-client/src/Dashboard.js
+++ b/react-client/src/Dashboard.js
@@ -3,23 +3,45 @@ import axios from 'axios'
 import { supabase } from './supabaseClient'
 import { isSessionExpired, startSession } from './utils/sessionManager'
 
-export default function Dashboard() {
+export default function Dashboard({ setPage }) {
     const [users, setUsers] = useState([])
     const [name, setName] = useState('')
     const [roomId, setRoomId] = useState('')
     const [message, setMessage] = useState('')
+    const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+    // 🔐 로그인 체크
+    useEffect(() => {
+        const checkAuth = async () => {
+            if (isSessionExpired()) {
+                await supabase.auth.signOut()
+                setPage('login')
+                return
+            }
+            
+            const { data: { session } } = await supabase.auth.getSession()
+            if (!session) {
+                setPage('login')
+            } else {
+                setIsAuthenticated(true)
+            }
+        }
+        checkAuth()
+    }, [setPage])
 
     const handleUpdate = async () => {
         // 🔐 세션 만료 체크
         if (isSessionExpired()) {
             setMessage('⚠️ 세션이 만료되었습니다. 다시 로그인해주세요.')
             await supabase.auth.signOut()
+            setPage('login')
             return
         }
 
         const { data: { session } } = await supabase.auth.getSession()
         if (!session) {
             setMessage('로그인이 필요합니다.')
+            setPage('login')
             return
         }
 

--- a/react-client/src/Dashboard.js
+++ b/react-client/src/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import axios from 'axios'
 import { supabase } from './supabaseClient'
+import { isSessionExpired, startSession } from './utils/sessionManager'
 
 export default function Dashboard() {
     const [users, setUsers] = useState([])
@@ -9,6 +10,13 @@ export default function Dashboard() {
     const [message, setMessage] = useState('')
 
     const handleUpdate = async () => {
+        // 🔐 세션 만료 체크
+        if (isSessionExpired()) {
+            setMessage('⚠️ 세션이 만료되었습니다. 다시 로그인해주세요.')
+            await supabase.auth.signOut()
+            return
+        }
+
         const { data: { session } } = await supabase.auth.getSession()
         if (!session) {
             setMessage('로그인이 필요합니다.')

--- a/react-client/src/Login.js
+++ b/react-client/src/Login.js
@@ -47,7 +47,7 @@ import axios from 'axios'
 import { supabase } from './supabaseClient'
 import { startSession } from './utils/sessionManager'
 
-export default function Login() {
+export default function Login({ onLogin }) {
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [token, setToken] = useState('')
@@ -82,6 +82,10 @@ export default function Login() {
                 }
             )
             setMessage('✅ 로그인 성공 및 서버 동기화 완료!')
+            // App.js에 로그인 상태 알리기
+            if (onLogin) {
+                onLogin()
+            }
         } catch (err) {
             console.error(err)
             setMessage('⚠️ 로그인은 성공했지만 서버 동기화 실패!')

--- a/react-client/src/Login.js
+++ b/react-client/src/Login.js
@@ -45,6 +45,7 @@
 import React, { useState } from 'react'
 import axios from 'axios'
 import { supabase } from './supabaseClient'
+import { startSession } from './utils/sessionManager'
 
 export default function Login() {
     const [email, setEmail] = useState('')
@@ -60,6 +61,9 @@ export default function Login() {
             setMessage(`❌ ${error.message}`)
             return
         }
+
+        // 🔐 세션 시작 시간 저장 (5분 타이머 시작)
+        startSession()
 
         // access_token 가져오기
         const accessToken = data.session.access_token

--- a/react-client/src/SignUp.js
+++ b/react-client/src/SignUp.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { supabase } from './supabaseClient'
 
-export default function SignUp() {
+export default function SignUp({ onLogin }) {
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [message, setMessage] = useState('')
@@ -9,8 +9,15 @@ export default function SignUp() {
     const handleSignUp = async (e) => {
         e.preventDefault()
         const { data, error } = await supabase.auth.signUp({ email, password })
-        if (error) setMessage(`❌ ${error.message}`)
-        else setMessage('✅ 회원가입 성공! 이메일 인증을 확인하세요.')
+        if (error) {
+            setMessage(`❌ ${error.message}`)
+        } else {
+            setMessage('✅ 회원가입 성공! 이메일 인증을 확인하세요.')
+            // 자동 로그인 상태 업데이트
+            if (onLogin) {
+                onLogin()
+            }
+        }
     }
 
     return (

--- a/react-client/src/pages/Message.js
+++ b/react-client/src/pages/Message.js
@@ -2,14 +2,35 @@
 import React, { useEffect, useRef, useState } from 'react'
 import axios from 'axios'
 import { supabase } from '../supabaseClient'
+import { isSessionExpired } from '../utils/sessionManager'
 
-export default function Message() {
+export default function Message({ setPage }) {
     const [roomId, setRoomId] = useState('')
     const [roomData, setRoomData] = useState(null)
     const [message, setMessage] = useState('')
     const [inputMessage, setInputMessage] = useState('')
     const [payload, setPayload] = useState(null)
     const channelRef = useRef(null)
+    const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+    // 🔐 로그인 체크
+    useEffect(() => {
+        const checkAuth = async () => {
+            if (isSessionExpired()) {
+                await supabase.auth.signOut()
+                setPage('login')
+                return
+            }
+            
+            const { data: { session } } = await supabase.auth.getSession()
+            if (!session) {
+                setPage('login')
+            } else {
+                setIsAuthenticated(true)
+            }
+        }
+        checkAuth()
+    }, [setPage])
 
     const joinRoom = async () => {
         if (!roomId) return alert('room_id를 입력하세요.')

--- a/react-client/src/utils/sessionManager.js
+++ b/react-client/src/utils/sessionManager.js
@@ -3,7 +3,7 @@
  * 5분(300초) 후 자동 만료
  */
 
-const SESSION_EXPIRE_TIME = 60 * 1000; // 5분 (밀리초)
+const SESSION_EXPIRE_TIME = 3 * 60 * 1000; // 5분 (밀리초)
 
 /**
  * 세션 시작 시간을 저장

--- a/react-client/src/utils/sessionManager.js
+++ b/react-client/src/utils/sessionManager.js
@@ -1,0 +1,69 @@
+/**
+ * 세션 만료 시간 관리 유틸리티
+ * 5분(300초) 후 자동 만료
+ */
+
+const SESSION_EXPIRE_TIME = 60 * 1000; // 5분 (밀리초)
+
+/**
+ * 세션 시작 시간을 저장
+ */
+export const startSession = () => {
+    localStorage.setItem('sessionStartTime', Date.now().toString());
+};
+
+/**
+ * 세션이 만료되었는지 확인
+ */
+export const isSessionExpired = () => {
+    const startTime = localStorage.getItem('sessionStartTime');
+    
+    if (!startTime) {
+        return true; // 시작 시간이 없으면 만료된 것으로 간주
+    }
+    
+    const elapsed = Date.now() - parseInt(startTime);
+    return elapsed >= SESSION_EXPIRE_TIME;
+};
+
+/**
+ * 남은 세션 시간 반환 (밀리초)
+ */
+export const getRemainingTime = () => {
+    const startTime = localStorage.getItem('sessionStartTime');
+    
+    if (!startTime) {
+        return 0;
+    }
+    
+    const elapsed = Date.now() - parseInt(startTime);
+    const remaining = SESSION_EXPIRE_TIME - elapsed;
+    
+    return remaining > 0 ? remaining : 0;
+};
+
+/**
+ * 남은 세션 시간을 분:초 형식으로 반환
+ */
+export const getFormattedRemainingTime = () => {
+    const remaining = getRemainingTime();
+    const minutes = Math.floor(remaining / 60000);
+    const seconds = Math.floor((remaining % 60000) / 1000);
+    
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+/**
+ * 세션 종료
+ */
+export const endSession = () => {
+    localStorage.removeItem('sessionStartTime');
+};
+
+/**
+ * 세션 연장
+ */
+export const extendSession = () => {
+    startSession();
+};
+


### PR DESCRIPTION
# 기존 토큰 관리 구조
- Supabase Auth → 회원가입, 로그인 → 토큰 발급까지
- 토큰 발급해서 로컬 스토리지에 저장(supabase sdk 기본 설정)
    - 세션 만료 기능이나 로그아웃 기능이 없어서 서버 재시작, 페이지 새로고침, 브라우저 재시작 시에도 해당 토큰으로 요청 가능
    - 즉, supabase.auth.getSession()은 브라우저에서 저장된 세션이 있으면 해당 세션을 읽어와서 해당 세션 안에 저장되어있는 토큰을 읽어와서 이를 통해 접근

# 변경된 토큰 관리 구조
- 어차피 모바일에서 구현하면 토큰 만료는 생각 안해도 되니까
- 현재 구조 유지한 채, 세션 만료 시간만 설정 - 3분
- 로그아웃 버튼 추가
- 즉 3분 자동 로그아웃, 수동 로그아웃 다 가능